### PR TITLE
Using SHA-256 instead of SHA-1

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@ div.vertical {
 	<script type="text/javascript" src="https://code.jquery.com/jquery-1.12.0.min.js"></script>
 
 
-	 <script type="text/javascript" src="https://rawcdn.githack.com/chrisveness/crypto/7067ee62f18c76dd4a9d372a00e647205460b62b/sha1.js"></script>
+	 <script type="text/javascript" src="https://rawcdn.githack.com/chrisveness/crypto/7067ee62f18c76dd4a9d372a00e647205460b62b/sha256.js"></script>
 
 	<script type="text/javascript">
 	"use strict";
@@ -93,7 +93,7 @@ div.vertical {
 	function loadPage(pwd) {
 
 		var hash= pwd;
-		hash= Sha1.hash(pwd);
+		hash= Sha256.hash(pwd);
 		var url= hash + "/index.html";
 
 		$.ajax({


### PR DESCRIPTION
SHA-1 is not considered secure anymore and is suggested to use SHA-256 instead.
This fix update the code to use SHA-256 instead.
After appling this patch you will need to change the name of your directories since the generated hash will be different